### PR TITLE
Make version parsing more tolerant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.3.1] - 2021-08-09
+
+### Fixed
+
+- updated dependencies to fix a crash on Windows (#46)
+- made parsing of version numbers more tolerant
+
 ## [1.3.0] - 2021-03-05
 
 ### Changed
@@ -72,3 +79,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Initial release
+
+[Unreleased]: https://github.com/sillsdev/SIL.NuGetCleaner/compare/v1.3.1...master
+[1.3.1]: https://github.com/sillsdev/SIL.NuGetCleaner/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/sillsdev/SIL.NuGetCleaner/compare/v1.2.2...v1.3.0
+[1.2.2]: https://github.com/sillsdev/SIL.NuGetCleaner/compare/v1.2.1...v1.2.2
+[1.2.1]: https://github.com/sillsdev/SIL.NuGetCleaner/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/sillsdev/SIL.NuGetCleaner/compare/v1.1.1...v1.2.0
+[1.1.1]: https://github.com/sillsdev/SIL.NuGetCleaner/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/sillsdev/SIL.NuGetCleaner/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/sillsdev/SIL.NuGetCleaner/compare/c897e3e...v1.0.1

--- a/SIL.NuGetCleaner.Tests/NuGetPackageTests.cs
+++ b/SIL.NuGetCleaner.Tests/NuGetPackageTests.cs
@@ -704,6 +704,5 @@ namespace SIL.NuGetCleaner.Tests
 			await sut.GetVersions();
 			Assert.That(sut.Maximum, Is.EqualTo(SemanticVersion.Parse("4.0.2")));
 		}
-
 	}
 }

--- a/SIL.NuGetCleaner.Tests/TolerantSemanticVersionTests.cs
+++ b/SIL.NuGetCleaner.Tests/TolerantSemanticVersionTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using NUnit.Framework;
+
+namespace SIL.NuGetCleaner.Tests
+{
+	[TestFixture]
+	public class TolerantSemanticVersionTests
+	{
+		[TestCase("1", 1, 0, 0, false)]
+		[TestCase("1.2", 1, 2, 0, false)]
+		[TestCase("1.2.3", 1, 2, 3, false)]
+		[TestCase("1.2.3.4", 1, 2, 3, false)]
+		[TestCase("1.2.3.4.5", 1, 2, 3, false)]
+		[TestCase("1.2.3-alpha", 1, 2, 3, true)]
+		[TestCase("1.2.3-alpha.1", 1, 2, 3, true)]
+		[TestCase("1.2.3-alpha0001", 1, 2, 3, true)]
+		[TestCase("1.2.3+1", 1, 2, 3, false)]
+		[TestCase("1.2.3-pre1+2", 1, 2, 3, true)]
+		[TestCase("1.2.3.4-alpha", 1, 2, 3, true)]
+		[TestCase("1.2.3.4-alpha.1", 1, 2, 3, true)]
+		[TestCase("1.2.3.4-alpha-1", 1, 2, 3, true)]
+		[TestCase("1.2.3alpha", 1, 2, 3, true)]
+		public void ParseVersion(string version, int expectedMajor, int expectedMinor, int expectedPatch, bool expectedPreRelease)
+		{
+			var parsedVersion = TolerantSemanticVersion.ParseVersion(version);
+			Assert.That(parsedVersion, Is.Not.Null);
+			Assert.That(parsedVersion.Major, Is.EqualTo(expectedMajor), "Major version");
+			Assert.That(parsedVersion.Minor, Is.EqualTo(expectedMinor), "Minor version");
+			Assert.That(parsedVersion.Patch, Is.EqualTo(expectedPatch), "Patch version");
+			Assert.That(parsedVersion.IsPrerelease, Is.EqualTo(expectedPreRelease), "IsPreRelease");
+			Assert.That($"{parsedVersion}", Is.EqualTo(version));
+		}
+
+		[TestCase("")]
+		[TestCase("One")]
+		[TestCase("1.Two")]
+		[TestCase("1bla")]
+		[TestCase("1.2bla")]
+		public void ParseVersionIllegalVersion(string version)
+		{
+			var parsedVersion = TolerantSemanticVersion.ParseVersion(version);
+			Assert.That(parsedVersion, Is.Null);
+		}
+	}
+}

--- a/SIL.NuGetCleaner/TolerantSemanticVersion.cs
+++ b/SIL.NuGetCleaner/TolerantSemanticVersion.cs
@@ -1,0 +1,109 @@
+// Copyright (c) 2021 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using NuGet.Versioning;
+
+namespace SIL.NuGetCleaner
+{
+	public class TolerantSemanticVersion: SemanticVersion
+	{
+		public static TolerantSemanticVersion ParseVersion(string versionString)
+		{
+			if (TryParse(versionString, out var result))
+				return new TolerantSemanticVersion(versionString, result);
+
+			// Regex inspired by https://github.com/adamreeve/semver.net
+			// Copyright (c) 2016 Adam Reeve
+			var looseRegex = new Regex(@"^
+					(\d+)                     # major version
+					(\.
+					(\d+)                     # minor version
+					(\.
+					(\d+)?                    # patch version
+					(\.\d+)*
+					(\-?([0-9A-Za-z\-\.]+))?  # pre-release version
+					(\+([0-9A-Za-z\-\.]+))?   # build metadata
+					\s*)?)?
+					$",
+				RegexOptions.IgnorePatternWhitespace);
+			var match = looseRegex.Match(versionString);
+			if (!match.Success)
+			{
+				Console.WriteLine($"ERROR: version doesn't comply to SemVer standard. Can't parse {versionString}");
+				return null;
+			}
+
+			var majorString = match.Groups[1].Success ? match.Groups[1].Value : "0";
+			var minorString = match.Groups[3].Success ? match.Groups[3].Value : "0";
+			var patchString = match.Groups[5].Success ? match.Groups[5].Value : "0";
+			var preRelease = match.Groups[8].Success? match.Groups[8].Value : "";
+			if (int.TryParse(majorString, out var major) &&
+				int.TryParse(minorString, out var minor) &&
+				int.TryParse(patchString, out var patch))
+			{
+				return new TolerantSemanticVersion(versionString, major, minor, patch, preRelease);
+			}
+
+			Console.WriteLine($"ERROR: version doesn't comply to SemVer standard. Can't parse {versionString}");
+			return null;
+		}
+
+		private readonly string _originalVersion;
+
+		public TolerantSemanticVersion(TolerantSemanticVersion version) : base(version)
+		{
+			_originalVersion = version._originalVersion;
+		}
+
+		private TolerantSemanticVersion(string originalVersion, SemanticVersion version) : base(version)
+		{
+			_originalVersion = originalVersion;
+		}
+
+		public TolerantSemanticVersion(int major, int minor, int patch) : base(major, minor, patch)
+		{
+		}
+
+		private TolerantSemanticVersion(string originalVersion, int major, int minor, int patch, string releaseLabel)
+			: base(major, minor, patch, releaseLabel)
+		{
+			_originalVersion = originalVersion;
+		}
+
+		public TolerantSemanticVersion(int major, int minor, int patch, string releaseLabel) : base(major, minor, patch, releaseLabel)
+		{
+		}
+
+		public TolerantSemanticVersion(int major, int minor, int patch, string releaseLabel, string metadata) : base(major, minor, patch, releaseLabel, metadata)
+		{
+		}
+
+		public TolerantSemanticVersion(int major, int minor, int patch, IEnumerable<string> releaseLabels, string metadata) : base(major, minor, patch, releaseLabels, metadata)
+		{
+		}
+
+		protected TolerantSemanticVersion(Version version, string releaseLabel = null, string metadata = null) : base(version, releaseLabel, metadata)
+		{
+		}
+
+		protected TolerantSemanticVersion(int major, int minor, int patch, int revision, string releaseLabel, string metadata) : base(major, minor, patch, revision, releaseLabel, metadata)
+		{
+		}
+
+		protected TolerantSemanticVersion(int major, int minor, int patch, int revision, IEnumerable<string> releaseLabels, string metadata) : base(major, minor, patch, revision, releaseLabels, metadata)
+		{
+		}
+
+		protected TolerantSemanticVersion(Version version, IEnumerable<string> releaseLabels, string metadata) : base(version, releaseLabels, metadata)
+		{
+		}
+
+		public override string ToString()
+		{
+			return _originalVersion;
+		}
+	}
+}


### PR DESCRIPTION
This change allows to parse version numbers that don't strictly
adhere to format specified by semver.org.

Also release version 1.3.1.